### PR TITLE
Use intelligent version sorting for tags

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ NEXT_RELEASE=$(date "+${DATE_FORMAT}")
 
 # ColemanB - Script looks for tags meeting requirements
 # and then looks up hash.
-LAST_RELEASE=$(git tag |grep "^20[^\-]*$" |sort -r |head -n 1)
+LAST_RELEASE=$(git tag --sort=v:refname |grep "^20[^\-]*$" |tail -n 1)
 echo "Last release : ${LAST_RELEASE}"
 
 LAST_HASH="$(git show-ref -s "${LAST_RELEASE}")"


### PR DESCRIPTION
Use git's `version:refname` sorting when listing tags to sort them as version numbers.
This will correctly sort version-like numbers.